### PR TITLE
Added support for Polylines and tileset polygons (#31)

### DIFF
--- a/src/TiledMap.cs
+++ b/src/TiledMap.cs
@@ -443,6 +443,7 @@ namespace TiledCS
             {
                 var nodesProperty = node.SelectNodes("properties/property");
                 var nodePolygon = node.SelectSingleNode("polygon");
+                var nodePolyline = node.SelectSingleNode("polyline");
                 var nodePoint = node.SelectSingleNode("point");
                 var nodeEllipse = node.SelectSingleNode("ellipse");
 
@@ -474,6 +475,23 @@ namespace TiledCS
                     }
 
                     obj.polygon = polygon;
+                }
+
+                if (nodePolyline != null)
+                {
+                    var points = nodePolyline.Attributes["points"].Value;
+                    var vertices = points.Split(' ');
+
+                    var polyline = new TiledPolyline();
+                    polyline.points = new float[vertices.Length * 2];
+
+                    for (var i = 0; i < vertices.Length; i++)
+                    {
+                        polyline.points[(i * 2) + 0] = float.Parse(vertices[i].Split(',')[0], CultureInfo.InvariantCulture);
+                        polyline.points[(i * 2) + 1] = float.Parse(vertices[i].Split(',')[1], CultureInfo.InvariantCulture);
+                    }
+
+                    obj.polyline = polyline;
                 }
 
                 if (nodeEllipse != null)

--- a/src/TiledModels.cs
+++ b/src/TiledModels.cs
@@ -153,6 +153,10 @@ namespace TiledCS
         /// </summary>
         public TiledPolygon polygon;
         /// <summary>
+        /// If an object was set to a polyline shape, this property will be set and can be used to access the polyline's data
+        /// </summary>
+        public TiledPolyline polyline;
+        /// <summary>
         /// If an object was set to a point shape, this property will be set
         /// </summary>
         public TiledPoint point;
@@ -166,6 +170,17 @@ namespace TiledCS
     /// Represents a polygon shape
     /// </summary>
     public class TiledPolygon
+    {
+        /// <summary>
+        /// The array of vertices where each two elements represent an x and y position. Like 'x,y,x,y,x,y,x,y'.
+        /// </summary>
+        public float[] points;
+    }
+
+    /// <summary>
+    /// Represents a poly line shape
+    /// </summary>
+    public class TiledPolyline
     {
         /// <summary>
         /// The array of vertices where each two elements represent an x and y position. Like 'x,y,x,y,x,y,x,y'.
@@ -220,6 +235,10 @@ namespace TiledCS
         /// The individual tile image
         /// </summary>
         public TiledImage image;
+        /// <summary>
+        /// Objects that this tile can have
+        /// </summary>
+        public TiledObject[] objects;
     }
 
     /// <summary>


### PR DESCRIPTION
This PR adds support for polylines (drawn with the polygon tool but it's not a closed polygon so Tiled calls this a "polyline"). It also adds support for the polygons drawn inside the tileset as mentioned in issue #31.

Cheers!