### PR TITLE
added polyline functionality

### DIFF
--- a/src/TiledMap.cs
+++ b/src/TiledMap.cs
@@ -520,6 +520,7 @@ namespace TiledCS
             {
                 var nodesProperty = node.SelectNodes("properties/property");
                 var nodePolygon = node.SelectSingleNode("polygon");
+                var nodePolyline = node.SelectSingleNode("polyline");
                 var nodePoint = node.SelectSingleNode("point");
                 var nodeEllipse = node.SelectSingleNode("ellipse");
 
@@ -553,6 +554,25 @@ namespace TiledCS
                     }
 
                     obj.polygon = polygon;
+                }
+
+                if (nodePolyline != null)
+                {
+                    var points = nodePolyline.Attributes["points"].Value;
+                    var vertices = points.Split(' ');
+
+                    var polyline = new TiledPolyline();
+                    polyline.points = new float[vertices.Length * 2];
+
+                    for (var i = 0; i < vertices.Length; i++)
+                    {
+                        polyline.points[(i * 2) + 0] =
+                            float.Parse(vertices[i].Split(',')[0], CultureInfo.InvariantCulture);
+                        polyline.points[(i * 2) + 1] =
+                            float.Parse(vertices[i].Split(',')[1], CultureInfo.InvariantCulture);
+                    }
+
+                    obj.polyline = polyline;
                 }
 
                 if (nodeEllipse != null)

--- a/src/TiledModels.cs
+++ b/src/TiledModels.cs
@@ -198,6 +198,11 @@ namespace TiledCS
         public TiledPolygon polygon;
 
         /// <summary>
+        /// If an object was set to a polyline shape, this property will be set and can be used to access the polyline's data
+        /// </summary>
+        public TiledPolyline polyline;
+
+        /// <summary>
         /// If an object was set to a point shape, this property will be set
         /// </summary>
         public TiledPoint point;
@@ -212,6 +217,17 @@ namespace TiledCS
     /// Represents a polygon shape
     /// </summary>
     public class TiledPolygon
+    {
+        /// <summary>
+        /// The array of vertices where each two elements represent an x and y position. Like 'x,y,x,y,x,y,x,y'.
+        /// </summary>
+        public float[] points;
+    }
+
+    /// <summary>
+    /// Represents a polyline shape
+    /// </summary>
+    public class TiledPolyline
     {
         /// <summary>
         /// The array of vertices where each two elements represent an x and y position. Like 'x,y,x,y,x,y,x,y'.


### PR DESCRIPTION
When creating a polygon on Tiled if the polygon is not closed a polyline is created instead, useful for paths or one way slopes.