### PR TITLE
Add @class property to TiledObject

### DIFF
--- a/src/TiledMap.cs
+++ b/src/TiledMap.cs
@@ -526,6 +526,7 @@ namespace TiledCS
                 var obj = new TiledObject();
                 obj.id = int.Parse(node.Attributes["id"].Value);
                 obj.name = node.Attributes["name"]?.Value;
+                obj.@class = node.Attributes["class"]?.Value;
                 obj.type = node.Attributes["type"]?.Value;
                 obj.gid = int.Parse(node.Attributes["gid"]?.Value ?? "0");
                 obj.x = float.Parse(node.Attributes["x"].Value, CultureInfo.InvariantCulture);

--- a/src/TiledModels.cs
+++ b/src/TiledModels.cs
@@ -158,6 +158,11 @@ namespace TiledCS
         public string type;
 
         /// <summary>
+        /// The object's class
+        /// </summary>
+        public string @class;
+
+        /// <summary>
         /// The object's x position in pixels
         /// </summary>
         public float x;

--- a/src/TiledTileset.cs
+++ b/src/TiledTileset.cs
@@ -227,6 +227,7 @@ namespace TiledCS
                 var obj = new TiledObject();
                 obj.id = int.Parse(node.Attributes["id"].Value);
                 obj.name = node.Attributes["name"]?.Value;
+                obj.@class = node.Attributes["class"]?.Value;
                 obj.type = node.Attributes["type"]?.Value;
                 obj.gid = int.Parse(node.Attributes["gid"]?.Value ?? "0");
                 obj.x = float.Parse(node.Attributes["x"].Value, CultureInfo.InvariantCulture);


### PR DESCRIPTION
Class property was missing from TiledObject. Defaults to `null` if not set, same as other attributes.