### PR TITLE
Fix parsing, add stream constructor

### DIFF
--- a/src/TiledCS.csproj
+++ b/src/TiledCS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <Version>3.1.0</Version>
+      <Version>3.1.1</Version>
       <Authors>Ruben Labruyere</Authors>
       <Company>Ruben Labruyere</Company>
       <PackageId>TiledCS</PackageId>
@@ -15,6 +15,7 @@
 
     <PropertyGroup>
       <TargetFramework>netstandard2.0</TargetFramework>
+      <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     </PropertyGroup>
 
 </Project>

--- a/src/TiledCS.csproj
+++ b/src/TiledCS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <Version>3.1.1</Version>
+      <Version>3.1.0</Version>
       <Authors>Ruben Labruyere</Authors>
       <Company>Ruben Labruyere</Company>
       <PackageId>TiledCS</PackageId>
@@ -15,7 +15,6 @@
 
     <PropertyGroup>
       <TargetFramework>netstandard2.0</TargetFramework>
-      <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     </PropertyGroup>
 
 </Project>

--- a/src/TiledMap.cs
+++ b/src/TiledMap.cs
@@ -303,6 +303,7 @@ namespace TiledCS
             if (attrVisible != null) tiledLayer.visible = attrVisible.Value == "1";
             if (attrLocked != null) tiledLayer.locked = attrLocked.Value == "1";
             if (attrTint != null) tiledLayer.tintcolor = attrTint.Value;
+            if (attrOpacity != null) tiledLayer.opacity = float.Parse(attrOpacity.Value);
             if (attrOffsetX != null) tiledLayer.offsetX = float.Parse(attrOffsetX.Value, CultureInfo.InvariantCulture);
             if (attrOffsetY != null) tiledLayer.offsetY = float.Parse(attrOffsetY.Value, CultureInfo.InvariantCulture);
             if (attrParallaxX != null) tiledLayer.offsetX = float.Parse(attrParallaxX.Value, CultureInfo.InvariantCulture);

--- a/src/TiledMap.cs
+++ b/src/TiledMap.cs
@@ -130,6 +130,18 @@ namespace TiledCS
         }
 
         /// <summary>
+        /// Loads a Tiled map in TMX format and parses it
+        /// </summary>
+        /// <param name="stream">Stream of opened tmx file</param>
+        /// <exception cref="TiledException">Thrown when the map could not be loaded</exception>
+        public TiledMap(Stream stream)
+        {
+            var streamReader = new StreamReader(stream);
+            var content = streamReader.ReadToEnd();
+            ParseXml(content);
+        }
+
+        /// <summary>
         /// Can be used to parse the content of a TMX map manually instead of loading it using the constructor
         /// </summary>
         /// <param name="xml">The tmx file content as string</param>
@@ -289,10 +301,10 @@ namespace TiledCS
             if (attrVisible != null) tiledLayer.visible = attrVisible.Value == "1";
             if (attrLocked != null) tiledLayer.locked = attrLocked.Value == "1";
             if (attrTint != null) tiledLayer.tintcolor = attrTint.Value;
-            if (attrOffsetX != null) tiledLayer.offsetX = float.Parse(attrOffsetX.Value);
-            if (attrOffsetY != null) tiledLayer.offsetY = float.Parse(attrOffsetY.Value);
-            if (attrParallaxX != null) tiledLayer.offsetX = float.Parse(attrParallaxX.Value);
-            if (attrParallaxY != null) tiledLayer.offsetY = float.Parse(attrParallaxY.Value);
+            if (attrOffsetX != null) tiledLayer.offsetX = float.Parse(attrOffsetX.Value, CultureInfo.InvariantCulture);
+            if (attrOffsetY != null) tiledLayer.offsetY = float.Parse(attrOffsetY.Value, CultureInfo.InvariantCulture);
+            if (attrParallaxX != null) tiledLayer.offsetX = float.Parse(attrParallaxX.Value, CultureInfo.InvariantCulture);
+            if (attrParallaxY != null) tiledLayer.offsetY = float.Parse(attrParallaxY.Value, CultureInfo.InvariantCulture);
             if (nodesProperty != null) tiledLayer.properties = ParseProperties(nodesProperty);
 
             ParseTileLayerData(nodeData, ref tiledLayer);
@@ -468,8 +480,8 @@ namespace TiledCS
             if (attrVisible != null) tiledLayer.visible = attrVisible.Value == "1";
             if (attrLocked != null) tiledLayer.locked = attrLocked.Value == "1";
             if (attrTint != null) tiledLayer.tintcolor = attrTint.Value;
-            if (attrOffsetX != null) tiledLayer.offsetX = int.Parse(attrOffsetX.Value);
-            if (attrOffsetY != null) tiledLayer.offsetY = int.Parse(attrOffsetY.Value);
+            if (attrOffsetX != null) tiledLayer.offsetX = float.Parse(attrOffsetX.Value, CultureInfo.InvariantCulture);
+            if (attrOffsetY != null) tiledLayer.offsetY = float.Parse(attrOffsetY.Value, CultureInfo.InvariantCulture);
             if (nodesProperty != null) tiledLayer.properties = ParseProperties(nodesProperty);
 
             return tiledLayer;
@@ -494,8 +506,8 @@ namespace TiledCS
             if (attrVisible != null) tiledLayer.visible = attrVisible.Value == "1";
             if (attrLocked != null) tiledLayer.locked = attrLocked.Value == "1";
             if (attrTint != null) tiledLayer.tintcolor = attrTint.Value;
-            if (attrOffsetX != null) tiledLayer.offsetX = int.Parse(attrOffsetX.Value);
-            if (attrOffsetY != null) tiledLayer.offsetY = int.Parse(attrOffsetY.Value);
+            if (attrOffsetX != null) tiledLayer.offsetX = float.Parse(attrOffsetX.Value, CultureInfo.InvariantCulture);
+            if (attrOffsetY != null) tiledLayer.offsetY = float.Parse(attrOffsetY.Value, CultureInfo.InvariantCulture);
             if (nodesProperty != null) tiledLayer.properties = ParseProperties(nodesProperty);
             if (nodeImage != null) tiledLayer.image = ParseImage(nodeImage);
 

--- a/src/TiledTileset.cs
+++ b/src/TiledTileset.cs
@@ -91,6 +91,18 @@ namespace TiledCS
         }
 
         /// <summary>
+        /// Loads a tileset in TSX format and parses it
+        /// </summary>
+        /// <param name="stream">The file stream of the TSX file</param>
+        /// <exception cref="TiledException">Thrown when the file could not be parsed</exception>
+        public TiledTileset(Stream stream)
+        {
+            var streamReader = new StreamReader(stream);
+            var content = streamReader.ReadToEnd();
+            ParseXml(content);
+        }
+
+        /// <summary>
         /// Can be used to parse the content of a TSX tileset manually instead of loading it using the constructor
         /// </summary>
         /// <param name="xml">The tmx file content as string</param>


### PR DESCRIPTION
* Added constructors that take Streams instead of file names.
* Fixed float parsing crashes (due to int.Parse and missing Invariant Culture)