### PR TITLE
Generate symbols for SourceLink

### DIFF
--- a/src/TiledCS.csproj
+++ b/src/TiledCS.csproj
@@ -15,6 +15,8 @@
 
     <PropertyGroup>
       <TargetFramework>netstandard2.0</TargetFramework>
+      <IncludeSymbols>true</IncludeSymbols>
+      <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The existing publish script will now upload a snupkg symbol package alongside the nupkg.

This will allow developers to step into the source of this package if necessary when debugging.

https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg