### PR TITLE
Included tile spacing and margin in source rectangle calculation

### DIFF
--- a/src/TiledMap.cs
+++ b/src/TiledMap.cs
@@ -707,8 +707,8 @@ namespace TiledCS
                 if (i == gid - mapTileset.firstgid)
                 {
                     var result = new TiledSourceRect();
-                    result.x = tileHor * tileset.TileWidth;
-                    result.y = tileVert * tileset.TileHeight;
+                    result.x = tileHor * (tileset.TileWidth + tileset.Spacing) + tileset.Margin;
+                    result.y = tileVert * (tileset.TileHeight + tileset.Spacing) + tileset.Margin;
                     result.width = tileset.TileWidth;
                     result.height = tileset.TileHeight;
 


### PR DESCRIPTION
[DualStickSheet.zip](https://github.com/TheBoneJarmer/TiledCS/files/9703069/DualStickSheet.zip)
Saw the discussion on #86. Here's a solution that also includes the margins and a tilesheet to test with. Note how each tile is 16x16 but has a 1 pixel border around it that matches the adjacent pixel. Margin is the thickness of the border around the entire tile sheet image whereas spacing is how many pixels are between any two tiles. This "extrusion" is used for solving gpu rounding errors that try to sample from the sprite sheet a tiny bit over the true border of the sprite and end up creating strange lines between tiles. Aseprite has an extrude option when exporting a tile sheet that does this for you if you want to make your own. https://www.aseprite.org/docs/sprite-sheet/