### PR TITLE
High level tile rotation access

### DIFF
--- a/src/Enums.cs
+++ b/src/Enums.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace TiledCS
 {
     /// <summary>
@@ -60,5 +62,47 @@ namespace TiledCS
         /// An object value which is the id of an object in the map
         /// </summary>
         Object
+    }
+
+    /// <summary>
+    /// Bitmap of flip states
+    /// </summary>
+    [Flags]
+    public enum Flip
+    {
+        /// <summary>
+        /// Tile is not flipped
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Tile is flipped horizontally
+        /// </summary>
+        Horizontal = 1 << 2,
+
+        /// <summary>
+        /// Tile is flipped vertically
+        /// </summary>
+        Vertical = 1 << 1,
+
+        /// <summary>
+        /// Tile is flipped diagonally
+        /// </summary>
+        Diagonal = 1 << 0,
+    }
+
+    [Flags]
+    internal enum Trans
+    {
+        None = 0,
+        Flip_H = 1 << 2,
+        Flip_V = 1 << 1,
+        Flip_D = 1 << 0,
+
+        Rotate_90 = Flip_D | Flip_H,
+        Rotate_180 = Flip_H | Flip_V,
+        Rotate_270 = Flip_V | Flip_D,
+
+        Rotate_90AndFlip_H = Flip_H | Flip_V | Flip_D,
     }
 }

--- a/src/TiledMap.cs
+++ b/src/TiledMap.cs
@@ -890,17 +890,17 @@ namespace TiledCS
         }
 
         /// <summary>
-        /// Object containing a tile transformation data
+        /// Object containing a tile transform data
         /// </summary>
         public struct TileTransform
         {
             /// <summary>
-            /// Bitmap of a tile flip states.
+            /// Bitmap of flip states for the current tile
             /// </summary>
             public Flip flipRaw;
 
             /// <summary>
-            /// Bitmap of a tile flip states.
+            /// Bitmap of flip states for the current tile.
             /// Ignores flips that are translated into a rotation.
             /// Use rawFlip to get the original flips.
             /// </summary>
@@ -919,7 +919,7 @@ namespace TiledCS
             public Point offset;
 
             /// <summary>
-            /// Creates a TileTransform with the given parameters.
+            /// Creates a TileTransform with the given parameters
             /// </summary>
             public TileTransform(Flip flipRaw, Flip flip, int rotation, Point offset)
             {

--- a/src/TiledMap.cs
+++ b/src/TiledMap.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
@@ -12,9 +13,9 @@ namespace TiledCS
     /// </summary>
     public class TiledMap
     {
-        const uint FLIPPED_HORIZONTALLY_FLAG = 0b10000000000000000000000000000000;
-        const uint FLIPPED_VERTICALLY_FLAG = 0b01000000000000000000000000000000;
-        const uint FLIPPED_DIAGONALLY_FLAG = 0b00100000000000000000000000000000;
+        const uint FLIPPED_HORIZONTALLY_FLAG = (uint)1 << 31; //0b10000000000000000000000000000000;
+        const uint FLIPPED_VERTICALLY_FLAG = (uint)1 << 30; //0b01000000000000000000000000000000;
+        const uint FLIPPED_DIAGONALLY_FLAG = (uint)1 << 29; //0b00100000000000000000000000000000;
 
         /// <summary>
         /// How many times we shift the FLIPPED flags to the right in order to store it in a byte.
@@ -802,7 +803,6 @@ namespace TiledCS
         /// <summary>
         /// Checks is a tile linked to an object is flipped vertically
         /// </summary>
-        /// <param name="layer">An entry of the TiledMap.layers array</param>
         /// <param name="tiledObject">The tiled object</param>
         /// <returns>True if the tile was flipped horizontally or False if not</returns>
         public bool IsTileFlippedVertical(TiledObject tiledObject)
@@ -856,6 +856,70 @@ namespace TiledCS
             }
             
             return (tiledObject.dataRotationFlag & (FLIPPED_DIAGONALLY_FLAG >> SHIFT_FLIP_FLAG_TO_BYTE)) > 0;
+        }
+
+        /// <summary>
+        /// This method returns an object containing transform information for the given tile
+        /// </summary>
+        /// <param name="layer">An entry of the TiledMap.layers array</param>
+        /// <param name="tileHor">The tile's horizontal position</param>
+        /// <param name="tileVert">The tile's vertical position</param>
+        public TileTransform GetTileTransform(TiledLayer layer, int tileHor, int tileVert)
+        {
+            return GetTileTransform(layer, tileHor + (tileVert * layer.width));
+        }
+
+        /// <summary>
+        /// This method returns an object containing transform information for the given tile
+        /// </summary>
+        /// <param name="layer">An entry of the TiledMap.layers array</param>
+        /// <param name="dataIndex">An index of the TiledLayer.data array</param>
+        public TileTransform GetTileTransform(TiledLayer layer, int dataIndex)
+        {
+            switch ((Trans)layer.dataRotationFlags[dataIndex])
+            {
+                case Trans.Flip_H:              return new TileTransform(Flip.Horizontal,  0, default);
+                case Trans.Flip_V:              return new TileTransform(Flip.Vertical,    0, default);
+                case Trans.Rotate_90:           return new TileTransform(Flip.None,       90, new Point(1, 0));
+                case Trans.Rotate_180:          return new TileTransform(Flip.None,      180, new Point(1, 1));
+                case Trans.Rotate_270:          return new TileTransform(Flip.None,      270, new Point(0, 1));
+                case Trans.Rotate_90AndFlip_H:  return new TileTransform(Flip.Horizontal, 90, new Point(1, 0));
+                default:                        return new TileTransform();
+            }
+        }
+
+        /// <summary>
+        /// Object containing a tile transformation data
+        /// </summary>
+        public struct TileTransform
+        {
+            /// <summary>
+            /// Bitmap of a tile flip states.
+            /// Ignores flips that are translated into a rotation.
+            /// </summary>
+            public Flip flip;
+
+            /// <summary>
+            /// Tile clockwise rotation in degrees
+            /// </summary>
+            public int rotation;
+
+            /// <summary>
+            /// Tile offset after a rotation around its upper-left corner.
+            /// Can be ignored if tile pivot is its center.
+            /// Multiply X and Y respectively for tileWidth and tileHeight to get the offset in pixels.
+            /// </summary>
+            public Point offset;
+
+            /// <summary>
+            /// Creates a TileTransform with the given parameters.
+            /// </summary>
+            public TileTransform(Flip flip, int rotation, Point offset)
+            {
+                this.flip = flip;
+                this.rotation = rotation;
+                this.offset = offset;
+            }
         }
     }
 }

--- a/src/TiledMap.cs
+++ b/src/TiledMap.cs
@@ -876,15 +876,16 @@ namespace TiledCS
         /// <param name="dataIndex">An index of the TiledLayer.data array</param>
         public TileTransform GetTileTransform(TiledLayer layer, int dataIndex)
         {
-            switch ((Trans)layer.dataRotationFlags[dataIndex])
+            Flip flipRaw = (Flip)layer.dataRotationFlags[dataIndex];
+            switch ((Trans)flipRaw)
             {
-                case Trans.Flip_H:              return new TileTransform(Flip.Horizontal,  0, default);
-                case Trans.Flip_V:              return new TileTransform(Flip.Vertical,    0, default);
-                case Trans.Rotate_90:           return new TileTransform(Flip.None,       90, new Point(1, 0));
-                case Trans.Rotate_180:          return new TileTransform(Flip.None,      180, new Point(1, 1));
-                case Trans.Rotate_270:          return new TileTransform(Flip.None,      270, new Point(0, 1));
-                case Trans.Rotate_90AndFlip_H:  return new TileTransform(Flip.Horizontal, 90, new Point(1, 0));
-                default:                        return new TileTransform();
+                case Trans.Rotate_270:          return new TileTransform(flipRaw, Flip.None,      270, new Point(0, 1));
+                case Trans.Rotate_180:          return new TileTransform(flipRaw, Flip.None,      180, new Point(1, 1));
+                case Trans.Rotate_90:           return new TileTransform(flipRaw, Flip.None,       90, new Point(1, 0));
+                case Trans.Rotate_90AndFlip_H:  return new TileTransform(flipRaw, Flip.Horizontal, 90, new Point(1, 0));
+                case Trans.Flip_H:              return new TileTransform(flipRaw, Flip.Horizontal,  0, default);
+                case Trans.Flip_V:              return new TileTransform(flipRaw, Flip.Vertical,    0, default);
+                default:                        return new TileTransform(flipRaw, Flip.None,        0, default);
             }
         }
 
@@ -895,7 +896,13 @@ namespace TiledCS
         {
             /// <summary>
             /// Bitmap of a tile flip states.
+            /// </summary>
+            public Flip flipRaw;
+
+            /// <summary>
+            /// Bitmap of a tile flip states.
             /// Ignores flips that are translated into a rotation.
+            /// Use rawFlip to get the original flips.
             /// </summary>
             public Flip flip;
 
@@ -914,8 +921,9 @@ namespace TiledCS
             /// <summary>
             /// Creates a TileTransform with the given parameters.
             /// </summary>
-            public TileTransform(Flip flip, int rotation, Point offset)
+            public TileTransform(Flip flipRaw, Flip flip, int rotation, Point offset)
             {
+                this.flipRaw = flipRaw;
                 this.flip = flip;
                 this.rotation = rotation;
                 this.offset = offset;


### PR DESCRIPTION
Trying to give high level access to tile rotation and other transform related information by implementing a GetTileTransform() method that returns a TileTransform object.

Said object contains:

    int Rotation => tile rotation in degrees inferred by flip flags
    Flip flip => original flip flags minus the ones translated into a rotation
    Flip flipRaw => original flip flags
    Point offset => tile offset to keep position unchanged after a rotation around its upper-left corner

I had a request to implement this in my MonoGame example repository, but seems reasonable to have it built into TiledCS.
This simplifies implementation for MonoGame by a lot, and I hope for other platforms too.

It is a known issue that when all flip flags are true (and you get both rotaton and flip in the TileTransform) the result of the transformation depends on the order these transformation are applied. It is implemented so that the rotation has to be applied first, and works fine with MonoGame, but may require some more attention.