### PR TITLE
99: add class element to tiledtile

### DIFF
--- a/src/TiledModels.cs
+++ b/src/TiledModels.cs
@@ -274,6 +274,11 @@ namespace TiledCS
         public string type;
 
         /// <summary>
+        /// The custom tile class, set by the user
+        /// </summary>
+        public string @class;
+
+        /// <summary>
         /// The terrain definitions as int array. These are indices indicating what part of a terrain and which terrain this tile represents.
         /// </summary>
         /// <remarks>In the map file empty space is used to indicate null or no value. However, since it is an int array I needed something so I decided to replace empty values with -1.</remarks>

--- a/src/TiledTileset.cs
+++ b/src/TiledTileset.cs
@@ -237,6 +237,7 @@ namespace TiledCS
 
                 var tile = new TiledTile();
                 tile.id = int.Parse(node.Attributes["id"].Value);
+                tile.@class = node.Attributes["class"]?.Value;
                 tile.type = node.Attributes["type"]?.Value;
                 tile.terrain = node.Attributes["terrain"]?.Value.Split(',').AsIntArray();
                 tile.properties = ParseProperties(nodesProperty);


### PR DESCRIPTION
Added support for the class property to TiledTile. A TiledTile represents a tile in a tilemap. Long term it _could_ make sense to take either of these alternative approaches:
* Check version number. If >= 1.9 then extract `class`. else extract `type`.
* Extract `class` if it exists, else extract `type`. 

I took the approach of adding a redundant "class" property since this is consistent with how the library handles the class/type data in TiledMaps: https://github.com/TheBoneJarmer/TiledCS/blob/main/src/TiledMap.cs#L526

And since this is technically just an xml prop, it doesn't break anything to simply support both.